### PR TITLE
Slider interface HTML issue

### DIFF
--- a/functions/admin/slider.php
+++ b/functions/admin/slider.php
@@ -107,7 +107,7 @@ function option_tree_slider_view( $id, $image, $int, $count ) {
       foreach( $image_slider_fields as $field ) {
       
         if ( $field['type'] == 'image' || $field['name'] == 'image' ){ ?>
-          <div>
+          <div style="clear: both;">
             <label><?php echo $field['label']; ?></label>      		  
             <input type="text" name="<?php echo $id; ?>[<?php echo $count; ?>][<?php echo $field['name']; ?>]" id="<?php echo $id; ?>-<?php echo $count; ?>-<?php echo $field['name']; ?>" value="<?php echo ( isset( $image[$field['name']] ) ? stripslashes($image[$field['name']]) : '' ); ?>" class="upload<?php if ( isset( $image[$field['name']] ) ) { echo ' has-file'; } ?>"/>
             <input id="upload_<?php echo $id ?>-<?php echo $count ?>-<?php echo $field['name'] ?>" class="upload_button" type="button" value="Upload" rel="<?php echo $int; ?>" />
@@ -144,6 +144,7 @@ function option_tree_slider_view( $id, $image, $int, $count ) {
         }
       }
       ?>
+      <div style="clear: both;"></div>
     </div>
   </div>
   <?php


### PR DESCRIPTION
When adding a slider to option tree that has 2 or more image (upload) fields coming after each other (coming in a row) as well as if image field comes last, the html looks really broken (floats are not cleared)

can be easily fixed by adding
at the end of the image upload element and a slider element itself in slider.php
