### PR TITLE
Change Required Capability to "Edit Theme Options"

### DIFF
--- a/includes/ot-settings-api.php
+++ b/includes/ot-settings-api.php
@@ -88,7 +88,7 @@ if ( ! class_exists( 'OT_Settings' ) ) {
             $page_hook = add_menu_page( 
               $page['page_title'], 
               $page['menu_title'], 
-              $page['capability'], 
+              'edit_theme_options', 
               $page['menu_slug'], 
               array( &$this, 'display_page' ), 
               $page['icon_url'],
@@ -100,7 +100,7 @@ if ( ! class_exists( 'OT_Settings' ) ) {
               $page['parent_slug'], 
               $page['page_title'], 
               $page['menu_title'], 
-              $page['capability'], 
+              'edit_theme_options', 
               $page['menu_slug'], 
               array( &$this, 'display_page' ) 
             );


### PR DESCRIPTION
Changing capabilities to 'edit_theme_options' is a much better approach as this enables access to the Theme Option to other roles if required. 

I was unable to figure out how or where the $page array was coming from so the capability has been manually hardcoded. Please fix this if there is an alternate solution. 

I had put in a similar fix [Previous Issue](https://github.com/valendesigns/option-tree/issues/1) for the previous version of OptionTree too see below. 
