### PR TITLE
Fixed PHP deprecated assigning of return value.

### DIFF
--- a/ot-loader.php
+++ b/ot-loader.php
@@ -386,7 +386,7 @@ if ( ! class_exists( 'OT_Loader' ) ) {
    *
    * @since     2.0
    */
-  $ot_loader =& new OT_Loader();
+  $ot_loader = new OT_Loader();
 
 }
 


### PR DESCRIPTION
(E_DEPRECATED) php warning: Assigning the return value of new by reference is deprecated.
