### PR TITLE
Fixed PHP deprecated assigning of return value #2

### DIFF
--- a/includes/ot-settings-api.php
+++ b/includes/ot-settings-api.php
@@ -844,7 +844,7 @@ if ( ! function_exists( 'ot_register_settings' ) ) {
     if ( ! $args )
       return;
       
-    $ot_settings =& new OT_Settings( $args );
+    $ot_settings = new OT_Settings( $args );
   }
 
 }


### PR DESCRIPTION
PHP Strict error "Assigning the return value of new by reference is deprecated".
OT_Settings
