### PR TITLE
Fix missing "Send to OptionTree" button in Custom Post Types with no "editor"

### DIFF
--- a/assets/js/ot-admin.js
+++ b/assets/js/ot-admin.js
@@ -294,7 +294,14 @@
                             if ( $('#TB_iframeContent').length > 0 && $('#TB_iframeContent').attr('src').indexOf( "&field_id=" ) !== -1 ) {
                               $('#TB_iframeContent').contents().find('#tab-type_url').hide();
                             }
-                            $('#TB_iframeContent').contents().find('.savesend .button').val(option_tree.upload_text); 
+                            $('#TB_iframeContent').contents().find('.savesend .button').val(option_tree.upload_text);
+
+                            if(!$('#TB_iframeContent').contents().find('.savesend input.button').length) {
+                                $('#TB_iframeContent').contents().find('.savesend').each(function(){
+                                    mediaItemID = $(this).closest('.media-item').attr('id').substring(11);
+                                    $(this).prepend('<input type="submit" name="send['+mediaItemID+']" class="button" value="'+option_tree.upload_text+'" />');
+                                });
+                            }
                           }, 50);
         tb_show('', 'media-upload.php?post_id='+post_id+'&field_id='+field_id+'&type=image&TB_iframe=1');
         window.send_to_editor = function(html) {


### PR DESCRIPTION
Hey there,

<a href="http://codex.wordpress.org/Function_Reference/register_post_type">Registering a custom post type</a> with no support for the editor (see <a href="http://codex.wordpress.org/Function_Reference/add_post_type_support#Parameters">post_type_support</a>) will cause the _"Send to OptionTree"_ button (originally _"Insert into Post"_) to be missing from the Media Library tab (in the Media Upload iframe):

<img src="https://public-maddim.s3.amazonaws.com/misc/Send%20to%20OptionTree%20Missing%20Button.png" />

I've encountered this issue with OptionTree when using the "Upload" option type in a metabox.

This fixes it by adding the button if it is missing.
Cheers!
JoNa
