### PR TITLE
Allow plugin/theme developers to filter sections/settings

### DIFF
--- a/includes/ot-functions-admin.php
+++ b/includes/ot-functions-admin.php
@@ -58,8 +58,8 @@ if ( ! function_exists( 'ot_register_theme_options_page' ) ) {
                 'button_text'     => apply_filters( 'ot_theme_options_button_text', __( 'Save Changes', 'option-tree' ) ),
                 'screen_icon'     => 'themes',
                 'contextual_help' => $contextual_help,
-                'sections'        => $sections,
-                'settings'        => $settings
+                'sections'        => apply_filters( 'ot_theme_options_sections', $sections ),
+                'settings'        => apply_filters( 'ot_theme_options_settings', $settings )
               )
             )
           )


### PR DESCRIPTION
I realize that there is a method you suggest in the documentation of your plugin - updating the option in the database. However, I feel that allowing for a filter (especially with the way that the options array is structured) provides for a better way to programmatically create options on the fly.

This method allows me to utilize both programmatic addition of options as well as adding options in the standard UI method.

I have examples of the filters I have added to this if desired.
