### PR TITLE
Make Radio Image source filterable

### DIFF
--- a/includes/ot-functions-option-types.php
+++ b/includes/ot-functions-option-types.php
@@ -1415,6 +1415,9 @@ if ( ! function_exists( 'ot_type_radio_image' ) ) {
           $src = str_replace( 'OT_URL', OT_URL, $choice['src'] );
           $src = str_replace( 'OT_THEME_URL', OT_THEME_URL, $src );
           
+          /* make radio image source filterable */
+          $src = apply_filters( 'ot_radio_image_src', $src, $field_id );
+          
           echo '<div class="option-tree-ui-radio-images">';
             echo '<p style="display:none"><input type="radio" name="' . esc_attr( $field_name ) . '" id="' . esc_attr( $field_id ) . '-' . esc_attr( $key ) . '" value="' . esc_attr( $choice['value'] ) . '"' . checked( $field_value, $choice['value'], false ) . ' class="option-tree-ui-radio option-tree-ui-images" /><label for="' . esc_attr( $field_id ) . '-' . esc_attr( $key ) . '">' . esc_attr( $choice['label'] ) . '</label></p>';
             echo '<img src="' . esc_url( $src ) . '" alt="' . esc_attr( $choice['label'] ) .'" title="' . esc_attr( $choice['label'] ) .'" class="option-tree-ui-radio-image ' . esc_attr( $field_class ) . ( $field_value == $choice['value'] ? ' option-tree-ui-radio-image-selected' : '' ) . '" />';


### PR DESCRIPTION
Related to https://github.com/valendesigns/option-tree/issues/109

Allows to filter the Radio Image src URL. If using OptionTree from a plugin (rather than from a theme), then paths to images will neither be in the theme directory (`OT_THEME_URL`) neither in the option-tree plugin directory (`OT_URL`), but will instead be located in the current plugin directory, which can be set only by the plugin itself using a filter.

Example usage:

```
add_filter('ot_radio_image_src', 'bitcommit_radio_image_src', 10, 2);
function bitcommit_radio_image_src($src, $field_id) {

    $src = str_replace( 'MY_CUSTOM_PLUGIN', plugin_dir_url( __FILE__ ), $src );
    return $src;
}
```
