### PR TITLE
Conditions aren't effective for Standard value in List Item when clicking "Add New"

### DIFF
--- a/assets/js/ot-admin.js
+++ b/assets/js/ot-admin.js
@@ -243,6 +243,7 @@
               OT_UI.init_sortable();
               OT_UI.init_select_wrapper();
               OT_UI.init_numeric_slider();
+              OT_UI.parse_condition();
             }, 500);
             self.processing = false;
           }


### PR DESCRIPTION
Conditions aren't effective for newly added List Items, so it affects only the Standard value. If making a change to the settings state then the condition apply properly, but initially all options are displayed despite the existing conditions.
