### PR TITLE
Fixed definitions of the OT_DIR and OT_URL constants for the OT theme mode

### DIFF
--- a/ot-loader.php
+++ b/ot-loader.php
@@ -277,7 +277,7 @@ if ( ! class_exists( 'OT_Loader' ) ) {
           define( 'OT_DIR', trailingslashit( trailingslashit( get_stylesheet_directory() ) . $path ) );
           define( 'OT_URL', trailingslashit( trailingslashit( get_stylesheet_directory_uri() ) . $path ) );
         } else {
-          $path = ltrim( end( @explode( end( @explode( '/', get_template_directory() ) ), dirname( __FILE__ ) ) ), '/' );
+          $path = ltrim( end( @explode( get_template(), str_replace( '\\', '/', dirname( __FILE__ ) ) ) ), '/' );
           define( 'OT_DIR', trailingslashit( trailingslashit( get_template_directory() ) . $path ) );
           define( 'OT_URL', trailingslashit( trailingslashit( get_template_directory_uri() ) . $path ) );
         }


### PR DESCRIPTION
On win platform it was impossible to put the option-tree pugin into the subdirectory of the theme. I am using bower as a dependency manager and have the option tree in `[...]/my-theme/bower_components/option-tree/` folder. The `basedir( __FILE__)` on win returns the backslashes `\` instead of slashes `/` so the whole explode thing did not work.

What I did is that I simplified getting the theme directory name - `get_template()` does that and performed the string replacement on `dirname` function to replace all `\` with `/` prior exploding.
