### PR TITLE
fix search order of contains condition string

### DIFF
--- a/assets/js/ot-admin.js
+++ b/assets/js/ot-admin.js
@@ -339,7 +339,7 @@
               result = ( parseInt( v1 ) >= parseInt( v2 ) );
               break;
             case 'contains':
-              result = ( v2.indexOf(v1) !== -1 ? true : false );
+              result = ( v1.indexOf(v2) !== -1 ? true : false );
               break; 
             case 'is':
               result = ( v1 == v2 );


### PR DESCRIPTION
I think the contains condition should be called this way:
`"target field value".indexOf("condition") !== -1`
