### PR TITLE
Auto-Fill Option IDs in the Theme Options UI Builder

### DIFF
--- a/assets/js/ot-admin.js
+++ b/assets/js/ot-admin.js
@@ -924,6 +924,17 @@
         $(this).find('.ot-theme-option-panels > .format-settings').prependTo($(this).find('.ot-theme-option-tabs'))
       
       }
+      
+      // Automatically fill option IDs with clean versions of their respective option labels
+      var optionIds = $(this).find('[type="text"][name$="id]"]');
+      var optionLabels = $(this).find('[type="text"][name$="label]"]');
+      if (optionIds.length) {
+        optionLabels.on('blur', function(e) {
+          var optionId = $(this).parents('.option-tree-setting-body').find('[type="text"][name$="id]"]')
+          var cleanOptionId = $(this).val().replace(/ /g, '_').toLowerCase();
+          if (optionId.val() === '') optionId.val(cleanOptionId);
+        })
+      }
     
     })
      


### PR DESCRIPTION
Automatically fill option IDs with clean versions of their respective option labels
