### PR TITLE
Google Fonts Option Type

### DIFF
--- a/assets/css/ot-admin.css
+++ b/assets/css/ot-admin.css
@@ -2660,6 +2660,19 @@ ul.ot-gallery-list li img {
 }
 
 /* -------------------------------------------------- 
+  :: Google Fonts
+  ---------------------------------------------------*/
+#option-tree-settings-api .option-tree-google-font-subsets-wrapper {
+  display: block;
+  clear: both;
+}
+#option-tree-settings-api .option-tree-google-font-subsets-wrapper p {
+  margin: 0.3em 0 !important;
+  float: left;
+  width: 100%;
+}
+
+/* -------------------------------------------------- 
   :: On/Off Switch
   ---------------------------------------------------*/
 .on-off-switch .slide-button {

--- a/assets/js/ot-admin.js
+++ b/assets/js/ot-admin.js
@@ -582,7 +582,7 @@
             var option = document.createElement('option');
             option.innerHTML = option.value = variant;
             return option;
-          }));
+          })).trigger('change');
         }
       }, update_subsets = function(input, subsets) {
         var subsetsUI = input.closest('.format-settings').find('.option-tree-google-font-subsets-wrapper');

--- a/assets/js/ot-admin.js
+++ b/assets/js/ot-admin.js
@@ -24,6 +24,7 @@
       this.init_tabs();
       this.init_radio_image_select();
       this.init_select_wrapper();
+      this.init_google_fonts();
       this.fix_upload_parent();
       this.fix_textarea();
       this.replicate_ajax();
@@ -555,18 +556,84 @@
       });
     },
     init_select_wrapper: function() {
-      $('.option-tree-ui-select').each(function () {
+      $('.option-tree-ui-select').each(function() {
         if ( ! $(this).parent().hasClass('select-wrapper') ) {
           $(this).wrap('<div class="select-wrapper" />');
           $(this).parent('.select-wrapper').prepend('<span>' + $(this).find('option:selected').text() + '</span>');
         }
       });
-      $(document).on('change', '.option-tree-ui-select', function () {
+      $(document).on('change', '.option-tree-ui-select', function() {
         $(this).prev('span').replaceWith('<span>' + $(this).find('option:selected').text() + '</span>');
-      })
+      });
       $(document).on($.browser.msie ? 'click' : 'change', '.option-tree-ui-select', function(event) {
         $(this).prev('span').replaceWith('<span>' + $(this).find('option:selected').text() + '</span>');
       });
+    },
+    init_google_fonts: function() {
+      if( ! option_tree.google_fonts ) {
+        return;
+      }
+
+      var update_variants = function(input, variants) {
+        var variantsUI = input.closest('.format-settings').find('.option-tree-google-font-variants');
+        if(variantsUI.length) {
+          variantsUI.children('option').not(':first').remove();
+          variantsUI.append($.map(variants, function(variant){
+            var option = document.createElement('option');
+            option.innerHTML = option.value = variant;
+            return option;
+          }));
+        }
+      }, update_subsets = function(input, subsets) {
+        var subsetsUI = input.closest('.format-settings').find('.option-tree-google-font-subsets-wrapper');
+        if( subsetsUI.length ) {
+          subsetsUI.empty();
+          subsetsUI.append($.map(subsets, function(subset) {
+            var input = document.createElement('input'),label = document.createElement('label');
+            input.type = 'checkbox';
+            input.id = ( subsetsUI.data('field-id-prefix') || '' ) + subset;
+            input.name =  ( subsetsUI.data('field-name') || '' );
+            label.innerHTML = subset;
+            $( label ).attr( 'for', input.id );
+            return $( document.createElement('p') ).append([input, label]);
+          }));
+        }
+      };
+
+      if( 'js' == option_tree.google_fonts.method && option_tree.google_fonts.fonts ) {
+        var fonts = option_tree.google_fonts.fonts || {};
+        $(document).on('change', '.option-tree-google-font-family', function() {
+          var input = $(this), family = input.val();
+          if( fonts.hasOwnProperty( family ) ) {
+            if( fonts[family].hasOwnProperty('variants') ) {
+              update_variants(input,fonts[family].variants);
+            }
+            if( fonts[family].hasOwnProperty('subsets') ) {
+              update_subsets(input,fonts[family].subsets);
+            }
+          }
+        });
+      } else {
+        $(document).on('change', '.option-tree-google-font-family', function() {
+          var input = $(this);
+          $.ajax({
+            url: option_tree.ajax,
+            type: 'POST',
+            dataType: 'json',
+            data: {
+              action: 'ot_google_font',
+              family: input.val()
+            }
+          }).done(function(response) {
+            if( response.hasOwnProperty('variants') ) {
+              update_variants(input,response.variants);
+            }
+            if( response.hasOwnProperty('subsets') ) {
+              update_subsets(input,response.subsets);
+            }
+          });
+        });
+      }
     },
     bind_colorpicker: function(field_id) {
       $('#'+field_id).wpColorPicker();

--- a/assets/js/ot-admin.js
+++ b/assets/js/ot-admin.js
@@ -622,7 +622,8 @@
             dataType: 'json',
             data: {
               action: 'ot_google_font',
-              family: input.val()
+              family: input.val(), 
+              field_id: input.attr('id').replace( /-google-font-family$/, '' )
             }
           }).done(function(response) {
             if( response.hasOwnProperty('variants') ) {

--- a/includes/ot-functions-admin.php
+++ b/includes/ot-functions-admin.php
@@ -4632,7 +4632,7 @@ function ot_available_google_font_variants( $family, $field_id ) {
 
   if( isset( $ot_google_fonts[ $family ], $ot_google_fonts[ $family ]['variants'] ) ) {
 
-    return apply_filters( 'ot_recognized_google_font_variants', $ot_google_fonts[ $family ]['variants'] );
+    return apply_filters( 'ot_recognized_google_font_variants', $ot_google_fonts[ $family ]['variants'], $field_id );
 
   }
 

--- a/includes/ot-functions-admin.php
+++ b/includes/ot-functions-admin.php
@@ -648,8 +648,10 @@ if ( ! function_exists( 'ot_admin_scripts' ) ) {
 
     /* prepare google font settings */
     $google_font = array(
-      'method' => apply_filters('ot_google_font_method','js')
+      'method' => apply_filters('ot_google_font_method','ajax')
     );
+
+    /* The js method does not filter font variants and subsets */
     if ( 'js' == $google_font['method'] ) {
       $google_font['fonts'] = ot_fetch_google_fonts();
     }
@@ -4624,13 +4626,13 @@ function ot_normalize_google_fonts( $google_fonts ) {
 
 }
 
-function ot_available_google_font_variants( $id ) {
+function ot_available_google_font_variants( $family, $field_id ) {
 
   $ot_google_fonts = ot_fetch_google_fonts();
 
-  if( isset( $ot_google_fonts[ $id ], $ot_google_fonts[ $id ]['variants'] ) ) {
+  if( isset( $ot_google_fonts[ $family ], $ot_google_fonts[ $family ]['variants'] ) ) {
 
-    return $ot_google_fonts[ $id ]['variants'];
+    return apply_filters( 'ot_recognized_google_font_variants', $ot_google_fonts[ $family ]['variants'] );
 
   }
 
@@ -4638,13 +4640,13 @@ function ot_available_google_font_variants( $id ) {
 
 }
 
-function ot_available_google_font_subsets( $id ) {
+function ot_available_google_font_subsets( $family, $field_id ) {
 
   $ot_google_fonts = ot_fetch_google_fonts();
 
-  if( isset( $ot_google_fonts[ $id ], $ot_google_fonts[ $id ]['subsets'] ) ) {
+  if( isset( $ot_google_fonts[ $family ], $ot_google_fonts[ $family ]['subsets'] ) ) {
 
-    return $ot_google_fonts[ $id ]['subsets'];
+    return apply_filters( 'ot_recognized_google_font_subsets', $ot_google_fonts[ $family ]['subsets'], $field_id );
 
   }
 

--- a/includes/ot-functions-admin.php
+++ b/includes/ot-functions-admin.php
@@ -4544,7 +4544,7 @@ function ot_fetch_google_fonts( $normalize = true ) {
 
     /* API url and key */
     $ot_google_fonts_api_url = apply_filters( 'ot_google_fonts_api_url', 'https://www.googleapis.com/webfonts/v1/webfonts' );
-    $ot_google_fonts_api_key = apply_filters( 'ot_google_fonts_api_key', '' );
+    $ot_google_fonts_api_key = apply_filters( 'ot_google_fonts_api_key', 'AIzaSyC-0ipgZdTRp2jeOct8w9GuPqjBX5LDDHE' );
 
     /* API arguments */
     $ot_google_fonts_fields = apply_filters( 'ot_google_fonts_fields', array( 'family', 'variants', 'subsets' ) );
@@ -4649,6 +4649,24 @@ function ot_available_google_font_subsets( $id ) {
   }
 
   return array();
+
+}
+
+function ot_recognized_google_font_families( $field_id ) {
+
+  $google_fonts = array();
+  
+  foreach( ot_fetch_google_fonts() as $id => $google_font ) {
+
+    if ( isset( $google_font['family'] ) ) {
+
+      $google_fonts[ $id ] = $google_font['family'];
+
+    }
+
+  }
+
+  return apply_filters( 'ot_recognized_google_font_families', $google_fonts, $field_id );
 
 }
 

--- a/includes/ot-functions-admin.php
+++ b/includes/ot-functions-admin.php
@@ -4538,7 +4538,7 @@ function ot_fetch_google_fonts( $normalize = true ) {
   $ot_google_fonts_cache_key = apply_filters( 'ot_google_fonts_cache_key', 'ot_google_fonts_cache' );
 
   /* get the fonts from cache */
-  $ot_google_fonts = get_transient( $ot_google_fonts_cache_key );
+  $ot_google_fonts = apply_filters( 'ot_google_fonts_cache', get_transient( $ot_google_fonts_cache_key ) );
 
   if ( ! is_array( $ot_google_fonts ) || empty( $ot_google_fonts ) ) {
 

--- a/includes/ot-functions-admin.php
+++ b/includes/ot-functions-admin.php
@@ -645,10 +645,19 @@ if ( ! function_exists( 'ot_admin_scripts' ) ) {
     
     /* load all the required scripts */
     wp_enqueue_script( 'ot-admin-js', OT_URL . 'assets/js/ot-admin.js', array( 'jquery', 'jquery-ui-tabs', 'jquery-ui-sortable', 'jquery-ui-slider', 'wp-color-picker', 'ace-editor', 'jquery-ui-datepicker', 'jquery-ui-timepicker' ), OT_VERSION );
+
+    /* prepare google font settings */
+    $google_font = array(
+      'method' => apply_filters('ot_google_font_method','js')
+    );
+    if ( 'js' == $google_font['method'] ) {
+      $google_font['fonts'] = ot_fetch_google_fonts();
+    }
     
     /* create localized JS array */
     $localized_array = array( 
       'ajax'                  => admin_url( 'admin-ajax.php' ),
+      'google_fonts'          => $google_font,
       'upload_text'           => apply_filters( 'ot_upload_text', __( 'Send to OptionTree', 'option-tree' ) ),
       'remove_media_text'     => __( 'Remove Media', 'option-tree' ),
       'reset_agree'           => __( 'Are you sure you want to reset back to the defaults?', 'option-tree' ),
@@ -2210,6 +2219,7 @@ if ( ! function_exists( 'ot_option_types_array' ) ) {
       'date-picker'               => __('Date Picker', 'option-tree'),
       'date-time-picker'          => __('Date Time Picker', 'option-tree'),
       'gallery'                   => __('Gallery', 'option-tree'),
+      'google-font'               => __('Google Font', 'option-tree'),
       'list-item'                 => __('List Item', 'option-tree'),
       'measurement'               => __('Measurement', 'option-tree'),
       'numeric-slider'            => __('Numeric Slider', 'option-tree'),
@@ -4518,6 +4528,134 @@ function ot_filter_std_value( $value = '', $std = '' ) {
 
   return $value;
   
+}
+
+function ot_fetch_google_fonts( $normalize = true ) {
+
+  /* Google Fonts cache key */
+  $ot_google_fonts_cache_key = apply_filters( 'ot_google_fonts_cache_key', 'ot_google_fonts_cache' );
+
+  /* get the fonts from cache */
+  $ot_google_fonts = get_transient( $ot_google_fonts_cache_key );
+
+  if ( ! is_array( $ot_google_fonts ) || empty( $ot_google_fonts ) ) {
+
+    $ot_google_fonts = array();
+
+    /* API url and key */
+    $ot_google_fonts_api_url = apply_filters( 'ot_google_fonts_api_url', 'https://www.googleapis.com/webfonts/v1/webfonts' );
+    $ot_google_fonts_api_key = apply_filters( 'ot_google_fonts_api_key', '' );
+
+    /* API arguments */
+    $ot_google_fonts_fields = apply_filters( 'ot_google_fonts_fields', array( 'family', 'variants', 'subsets' ) );
+    $ot_google_fonts_sort   = apply_filters( 'ot_google_fonts_sort', 'alpha' );
+
+    /* Initiate API request */
+    $ot_google_fonts_query_args = array(
+      'key'    => $ot_google_fonts_api_key, 
+      'fields' => 'items(' . implode( ',', $ot_google_fonts_fields ) . ')', 
+      'sort'   => $ot_google_fonts_sort
+    );
+
+    /* Build and make the request */
+    $ot_google_fonts_query = add_query_arg( $ot_google_fonts_query_args, $ot_google_fonts_api_url );
+    $ot_google_fonts_response = wp_safe_remote_get( $ot_google_fonts_query, array( 'sslverify' => false, 'timeout' => 15 ) );
+
+    /* continue if we got a valid response */
+    if ( 200 == wp_remote_retrieve_response_code( $ot_google_fonts_response ) ) {
+
+      if ( $response_body = wp_remote_retrieve_body( $ot_google_fonts_response ) ) {
+
+        /* JSON decode the response body and cache the result */
+        $ot_google_fonts_data = json_decode( trim( $response_body ), true );
+
+        if ( is_array( $ot_google_fonts_data ) && isset( $ot_google_fonts_data['items'] ) ) {
+
+          $ot_google_fonts = $ot_google_fonts_data['items'];
+          set_transient( $ot_google_fonts_cache_key, $ot_google_fonts, WEEK_IN_SECONDS );
+
+        }
+
+      }
+
+    }
+
+  }
+
+  return $normalize ? ot_normalize_google_fonts( $ot_google_fonts ) : $ot_google_fonts;
+
+}
+
+function ot_normalize_google_fonts( $google_fonts ) {
+
+  $ot_normalized_google_fonts = array();
+
+  if ( is_array( $google_fonts ) && ! empty( $google_fonts ) ) {
+
+    foreach( $google_fonts as $google_font ) {
+
+      if( isset( $google_font['family'] ) ) {
+
+        $id = ot_google_font_id( $google_font['family'] );
+
+        $ot_normalized_google_fonts[ $id ] = array(
+          'family' => $google_font['family']
+        );
+
+        if( isset( $google_font['variants'] ) ) {
+
+          $ot_normalized_google_fonts[ $id ]['variants'] = $google_font['variants'];
+
+        }
+
+        if( isset( $google_font['subsets'] ) ) {
+
+          $ot_normalized_google_fonts[ $id ]['subsets'] = $google_font['subsets'];
+
+        }
+
+      }
+
+    }
+
+  }
+
+  return $ot_normalized_google_fonts;
+
+}
+
+function ot_available_google_font_variants( $id ) {
+
+  $ot_google_fonts = ot_fetch_google_fonts();
+
+  if( isset( $ot_google_fonts[ $id ], $ot_google_fonts[ $id ]['variants'] ) ) {
+
+    return $ot_google_fonts[ $id ]['variants'];
+
+  }
+
+  return array();
+
+}
+
+function ot_available_google_font_subsets( $id ) {
+
+  $ot_google_fonts = ot_fetch_google_fonts();
+
+  if( isset( $ot_google_fonts[ $id ], $ot_google_fonts[ $id ]['subsets'] ) ) {
+
+    return $ot_google_fonts[ $id ]['subsets'];
+
+  }
+
+  return array();
+
+}
+
+function ot_google_font_id( $family ) {
+
+  return str_replace( ' ', '+', $family );
+
 }
 
 /**

--- a/includes/ot-functions-option-types.php
+++ b/includes/ot-functions-option-types.php
@@ -831,6 +831,90 @@ if ( ! function_exists( 'ot_type_gallery' ) ) {
 }
 
 /**
+ * Google Font option type.
+ *
+ * See @ot_display_by_type to see the full list of available arguments.
+ *
+ * @param     array     An array of arguments.
+ * @return    string
+ *
+ * @access    public
+ * @since     @version
+ */
+if ( ! function_exists( 'ot_type_google_font' ) ) {
+  
+  function ot_type_google_font( $args = array() ) {
+
+    /* turns arguments array into variables */
+    extract( $args );
+    
+    /* verify a description */
+    $has_desc = $field_desc ? true : false;
+    
+    /* format setting outer wrapper */
+    echo '<div class="format-setting type-google-fonts ' . ( $has_desc ? 'has-desc' : 'no-desc' ) . '">';
+      
+      /* description */
+      echo $has_desc ? '<div class="description">' . htmlspecialchars_decode( $field_desc ) . '</div>' : '';
+      
+      /* format setting inner wrapper */
+      echo '<div class="format-setting-inner">'; 
+        
+        /* allow fields to be filtered */
+        $ot_recognized_google_fonts_fields = apply_filters( 'ot_recognized_google_fonts_fields', array( 
+          'font-family', 
+          'font-variant', 
+          'font-subsets'
+        ), $field_id );
+
+        /* fetch google fonts */
+        $ot_google_fonts = ot_fetch_google_fonts();
+        
+        /* build font family */
+        $font_family = isset( $field_value['font-family'] ) ? $field_value['font-family'] : '';
+        echo '<select name="' . esc_attr( $field_name ) . '[font-family]" id="' . esc_attr( $field_id ) . '-google-font-family" class="option-tree-ui-select option-tree-google-font-family ' . esc_attr( $field_class ) . '">';
+          echo '<option value="">' . __( 'select a font family', 'option-tree' ) . '</option>';
+          // foreach ( ot_recognized_google_font_families( $ot_fetched_google_fonts, $field_id ) as $key => $value ) {
+          foreach ( $ot_google_fonts as $key => $value ) {
+            if( isset( $value['family'] ) ) {
+              echo '<option value="' . esc_attr( $key ) . '" ' . selected( $font_family, $key, false ) . '>' . esc_html( $value['family'] ) . '</option>';
+            }
+          }
+        echo '</select>';
+
+        /* build font variant */
+        if ( in_array( 'font-variant', $ot_recognized_google_fonts_fields ) ) {
+          $font_variant = isset( $field_value['font-variant'] ) ? esc_attr( $field_value['font-variant'] ) : '';
+          echo '<select name="' . esc_attr( $field_name ) . '[font-variant]" id="' . esc_attr( $field_id ) . '-google-font-variant" class="option-tree-ui-select option-tree-google-font-variants ' . esc_attr( $field_class ) . '">';
+            echo '<option value="">' . __( 'select a font variant', 'option-tree' ) . '</option>';
+            foreach ( ot_available_google_font_variants( $font_family ) as $variant ) {
+              echo '<option value="' . esc_attr( $variant ) . '" ' . selected( $font_variant, $variant, false ) . '>' . esc_html( $variant ) . '</option>';
+            }
+          echo '</select>';
+        }
+        
+        /* build font subsets */
+        if ( in_array( 'font-subsets', $ot_recognized_google_fonts_fields ) ) {
+          $font_subsets = isset( $field_value['font-subsets'] ) ? $field_value['font-subsets'] : array();
+          echo '<div class="option-tree-google-font-subsets-wrapper" data-field-id-prefix="' . esc_attr( $field_id ) . '-google-font-subsets-" data-field-name="' . esc_attr( $field_name ) . '[font-subsets][]" data-field-class="option-tree-ui-checkbox ' . esc_attr( $field_class ) . '">';
+          foreach ( ot_available_google_font_subsets( $font_family ) as $subset ) {
+            echo '<p>';
+              echo '<input type="checkbox" name="' . esc_attr( $field_name ) . '[font-subsets][]" id="' . esc_attr( $field_id ) . '-google-font-subsets-' . $subset . '" value="' . esc_attr( $subset ) . '" ' . checked( in_array( $subset, $font_subsets ), true, false )  . ' class="option-tree-ui-checkbox ' . esc_attr( $field_class ) . '" />';
+              echo '<label for="' . esc_attr( $field_id ) . '-google-font-subsets-' . $subset . '">' . esc_html( $subset ) . '</label>';
+            echo '</p>';
+          }
+          echo '</div>';
+        }
+        
+      echo '</div>';
+      
+    echo '</div>';
+    
+  }
+  
+}
+
+/**
  * List Item option type.
  *
  * See @ot_display_by_type to see the full list of available arguments.

--- a/includes/ot-functions-option-types.php
+++ b/includes/ot-functions-option-types.php
@@ -878,10 +878,9 @@ if ( ! function_exists( 'ot_type_google_font' ) ) {
         /* build font variant */
         if ( in_array( 'font-variant', $ot_recognized_google_fonts_fields ) ) {
           $font_variant = isset( $field_value['font-variant'] ) ? esc_attr( $field_value['font-variant'] ) : '';
-          $variants = apply_filters( 'ot_recognized_google_font_variants', ot_available_google_font_variants( $font_family ), $field_id );
           echo '<select name="' . esc_attr( $field_name ) . '[font-variant]" id="' . esc_attr( $field_id ) . '-google-font-variant" class="option-tree-ui-select option-tree-google-font-variants ' . esc_attr( $field_class ) . '">';
             echo '<option value="">' . __( 'select a font variant', 'option-tree' ) . '</option>';
-            foreach ( $variants as $variant ) {
+            foreach ( ot_available_google_font_variants( $font_family, $field_id ) as $variant ) {
               echo '<option value="' . esc_attr( $variant ) . '" ' . selected( $font_variant, $variant, false ) . '>' . esc_html( $variant ) . '</option>';
             }
           echo '</select>';
@@ -890,9 +889,8 @@ if ( ! function_exists( 'ot_type_google_font' ) ) {
         /* build font subsets */
         if ( in_array( 'font-subsets', $ot_recognized_google_fonts_fields ) ) {
           $font_subsets = isset( $field_value['font-subsets'] ) ? $field_value['font-subsets'] : array();
-          $subsets = apply_filters( 'ot_recognized_google_font_subsets', ot_available_google_font_subsets( $font_family ), $field_id );
           echo '<div class="option-tree-google-font-subsets-wrapper" data-field-id-prefix="' . esc_attr( $field_id ) . '-google-font-subsets-" data-field-name="' . esc_attr( $field_name ) . '[font-subsets][]" data-field-class="option-tree-ui-checkbox ' . esc_attr( $field_class ) . '">';
-          foreach ( $subsets as $subset ) {
+          foreach ( ot_available_google_font_subsets( $font_family, $field_id ) as $subset ) {
             echo '<p>';
               echo '<input type="checkbox" name="' . esc_attr( $field_name ) . '[font-subsets][]" id="' . esc_attr( $field_id ) . '-google-font-subsets-' . $subset . '" value="' . esc_attr( $subset ) . '" ' . checked( in_array( $subset, $font_subsets ), true, false )  . ' class="option-tree-ui-checkbox ' . esc_attr( $field_class ) . '" />';
               echo '<label for="' . esc_attr( $field_id ) . '-google-font-subsets-' . $subset . '">' . esc_html( $subset ) . '</label>';

--- a/includes/ot-functions-option-types.php
+++ b/includes/ot-functions-option-types.php
@@ -861,7 +861,7 @@ if ( ! function_exists( 'ot_type_google_font' ) ) {
       echo '<div class="format-setting-inner">'; 
         
         /* allow fields to be filtered */
-        $ot_recognized_google_fonts_fields = apply_filters( 'ot_recognized_google_fonts_fields', array(
+        $ot_recognized_google_fonts_fields = apply_filters( 'ot_recognized_google_font_fields', array(
           'font-variant', 
           'font-subsets'
         ), $field_id );

--- a/includes/ot-functions-option-types.php
+++ b/includes/ot-functions-option-types.php
@@ -861,33 +861,27 @@ if ( ! function_exists( 'ot_type_google_font' ) ) {
       echo '<div class="format-setting-inner">'; 
         
         /* allow fields to be filtered */
-        $ot_recognized_google_fonts_fields = apply_filters( 'ot_recognized_google_fonts_fields', array( 
-          'font-family', 
+        $ot_recognized_google_fonts_fields = apply_filters( 'ot_recognized_google_fonts_fields', array(
           'font-variant', 
           'font-subsets'
         ), $field_id );
-
-        /* fetch google fonts */
-        $ot_google_fonts = ot_fetch_google_fonts();
         
         /* build font family */
         $font_family = isset( $field_value['font-family'] ) ? $field_value['font-family'] : '';
         echo '<select name="' . esc_attr( $field_name ) . '[font-family]" id="' . esc_attr( $field_id ) . '-google-font-family" class="option-tree-ui-select option-tree-google-font-family ' . esc_attr( $field_class ) . '">';
           echo '<option value="">' . __( 'select a font family', 'option-tree' ) . '</option>';
-          // foreach ( ot_recognized_google_font_families( $ot_fetched_google_fonts, $field_id ) as $key => $value ) {
-          foreach ( $ot_google_fonts as $key => $value ) {
-            if( isset( $value['family'] ) ) {
-              echo '<option value="' . esc_attr( $key ) . '" ' . selected( $font_family, $key, false ) . '>' . esc_html( $value['family'] ) . '</option>';
-            }
+          foreach ( ot_recognized_google_font_families( $field_id ) as $key => $value ) {
+            echo '<option value="' . esc_attr( $key ) . '" ' . selected( $font_family, $key, false ) . '>' . esc_html( $value ) . '</option>';
           }
         echo '</select>';
 
         /* build font variant */
         if ( in_array( 'font-variant', $ot_recognized_google_fonts_fields ) ) {
           $font_variant = isset( $field_value['font-variant'] ) ? esc_attr( $field_value['font-variant'] ) : '';
+          $variants = apply_filters( 'ot_recognized_google_font_variants', ot_available_google_font_variants( $font_family ), $field_id );
           echo '<select name="' . esc_attr( $field_name ) . '[font-variant]" id="' . esc_attr( $field_id ) . '-google-font-variant" class="option-tree-ui-select option-tree-google-font-variants ' . esc_attr( $field_class ) . '">';
             echo '<option value="">' . __( 'select a font variant', 'option-tree' ) . '</option>';
-            foreach ( ot_available_google_font_variants( $font_family ) as $variant ) {
+            foreach ( $variants as $variant ) {
               echo '<option value="' . esc_attr( $variant ) . '" ' . selected( $font_variant, $variant, false ) . '>' . esc_html( $variant ) . '</option>';
             }
           echo '</select>';
@@ -896,8 +890,9 @@ if ( ! function_exists( 'ot_type_google_font' ) ) {
         /* build font subsets */
         if ( in_array( 'font-subsets', $ot_recognized_google_fonts_fields ) ) {
           $font_subsets = isset( $field_value['font-subsets'] ) ? $field_value['font-subsets'] : array();
+          $subsets = apply_filters( 'ot_recognized_google_font_subsets', ot_available_google_font_subsets( $font_family ), $field_id );
           echo '<div class="option-tree-google-font-subsets-wrapper" data-field-id-prefix="' . esc_attr( $field_id ) . '-google-font-subsets-" data-field-name="' . esc_attr( $field_name ) . '[font-subsets][]" data-field-class="option-tree-ui-checkbox ' . esc_attr( $field_class ) . '">';
-          foreach ( ot_available_google_font_subsets( $font_family ) as $subset ) {
+          foreach ( $subsets as $subset ) {
             echo '<p>';
               echo '<input type="checkbox" name="' . esc_attr( $field_name ) . '[font-subsets][]" id="' . esc_attr( $field_id ) . '-google-font-subsets-' . $subset . '" value="' . esc_attr( $subset ) . '" ' . checked( in_array( $subset, $font_subsets ), true, false )  . ' class="option-tree-ui-checkbox ' . esc_attr( $field_class ) . '" />';
               echo '<label for="' . esc_attr( $field_id ) . '-google-font-subsets-' . $subset . '">' . esc_html( $subset ) . '</label>';

--- a/ot-loader.php
+++ b/ot-loader.php
@@ -516,6 +516,9 @@ if ( ! class_exists( 'OT_Loader' ) ) {
       
       /* AJAX call to create a new social link */
       add_action( 'wp_ajax_add_social_links', array( $this, 'add_social_links' ) );
+
+      /* AJAX call to retrieve Google Font data */
+      add_action( 'wp_ajax_ot_google_font', array( $this, 'retrieve_google_font' ) );
       
       // Adds the temporary hacktastic shortcode
       add_filter( 'media_view_settings', array( $this, 'shortcode' ), 10, 2 );
@@ -724,6 +727,23 @@ if ( ! class_exists( 'OT_Loader' ) ) {
       
       }
       
+    }
+
+    public function retrieve_google_font() {
+
+      if ( isset( $_POST['family'] ) ) {
+
+        $ot_google_font_variants = ot_available_google_font_variants( $_POST['family'] );
+        $ot_google_font_subsets  = ot_available_google_font_subsets( $_POST['family'] );
+
+        echo json_encode( array(
+          'variants' => $ot_google_font_variants,
+          'subsets'  => $ot_google_font_subsets
+        ) );
+        exit();
+
+      }
+
     }
     
     /**

--- a/ot-loader.php
+++ b/ot-loader.php
@@ -731,10 +731,10 @@ if ( ! class_exists( 'OT_Loader' ) ) {
 
     public function retrieve_google_font() {
 
-      if ( isset( $_POST['family'] ) ) {
+      if ( isset( $_POST['family'], $_POST['field_id'] ) ) {
 
-        $ot_google_font_variants = ot_available_google_font_variants( $_POST['family'] );
-        $ot_google_font_subsets  = ot_available_google_font_subsets( $_POST['family'] );
+        $ot_google_font_variants = ot_available_google_font_variants( $_POST['family'], $_POST['field_id'] );
+        $ot_google_font_subsets  = ot_available_google_font_subsets( $_POST['family'], $_POST['field_id'] );
 
         echo json_encode( array(
           'variants' => $ot_google_font_variants,


### PR DESCRIPTION
Instead of the Typography option type, I've build this Google Fonts option type for a project I'm working on. This option type makes it possible to select a Google Font, while updating the font variants and subsets dynamically either via AJAX or JS. Also added to option tree is the ability to fetch Google Fonts, by supplying the API key via 'ot_google_fonts_api_key filter'.

It might be better if this option can be somehow integrated into the Typography option type so we don't have both of them. Please do the necessary edits and commenting if you wish to merge this into core.

Thanks!