### PR TITLE
Check for post_title instead of post_name in ot_get_media_post_ID()

### DIFF
--- a/includes/ot-functions-admin.php
+++ b/includes/ot-functions-admin.php
@@ -692,7 +692,7 @@ if ( ! function_exists( 'ot_get_media_post_ID' ) ) {
   function ot_get_media_post_ID() {
     global $wpdb;
     
-    return $wpdb->get_var( "SELECT ID FROM $wpdb->posts WHERE `post_name` = 'media' AND `post_type` = 'option-tree' AND `post_status` = 'private'" );
+    return $wpdb->get_var( "SELECT ID FROM $wpdb->posts WHERE `post_title` = 'Media' AND `post_type` = 'option-tree' AND `post_status` = 'private'" );
     
   }
 


### PR DESCRIPTION
Since slugs must be unique and there is no guarantee the slug "media" will be available for OptionTree (it is a very common word within WordPress after all), the only safe way to retrieve the media post is by post_title.

Without this change, if any taxonomy term or post has reserved the slug 'media', the site will create a new media post infinitely, on every admin page load.

A client's site had 60,000 of these posts causing every page load to take over 60 seconds.  This is because `wp_insert_post()` has to call `wp_unique_post_slug()` each time, to calculate a slug for each new media post.  

Longer term, I think it would be wise to simply store the media post ID in an option and retrieve it each time. Looking up the post by name, post_type, etc is inefficient in my opinion.
