### PR TITLE
Added custom_fields option to meta boxes and settings

### DIFF
--- a/includes/ot-functions-admin.php
+++ b/includes/ot-functions-admin.php
@@ -4432,6 +4432,7 @@ if ( ! function_exists( 'ot_list_item_view' ) ) {
           'field_operator'    => isset( $field['operator'] ) ? $field['operator'] : 'and',
           'field_choices'     => isset( $field['choices'] ) && ! empty( $field['choices'] ) ? $field['choices'] : array(),
           'field_settings'    => isset( $field['settings'] ) && ! empty( $field['settings'] ) ? $field['settings'] : array(),
+          'field_custom_fields' => isset( $field['custom_fields'] ) && ! empty( $field['custom_fields'] ) ? $field['custom_fields'] : array(),
           'post_id'           => $post_id,
           'get_option'        => $get_option
         );
@@ -4574,6 +4575,7 @@ if ( ! function_exists( 'ot_social_links_view' ) ) {
           'field_operator'    => isset( $field['operator'] ) ? $field['operator'] : 'and',
           'field_choices'     => isset( $field['choices'] ) && ! empty( $field['choices'] ) ? $field['choices'] : array(),
           'field_settings'    => isset( $field['settings'] ) && ! empty( $field['settings'] ) ? $field['settings'] : array(),
+          'field_custom_fields' => isset( $field['custom_fields'] ) && ! empty( $field['custom_fields'] ) ? $field['custom_fields'] : array(),
           'post_id'           => $post_id,
           'get_option'        => $get_option
         );

--- a/includes/ot-functions-option-types.php
+++ b/includes/ot-functions-option-types.php
@@ -24,6 +24,7 @@
  * @param     string      $field_class Extra CSS classes.
  * @param     array       $field_choices The array of option choices.
  * @param     array       $field_settings The array of settings for a list item.
+ * @param     array       $field_custom_fields The array of optional custom fields.
  * @return    string
  *
  * @access    public

--- a/includes/ot-meta-box-api.php
+++ b/includes/ot-meta-box-api.php
@@ -101,6 +101,7 @@ if ( ! class_exists( 'OT_Meta_Box' ) ) {
             'field_operator'    => isset( $field['operator'] ) ? $field['operator'] : 'and',
             'field_choices'     => isset( $field['choices'] ) ? $field['choices'] : array(),
             'field_settings'    => isset( $field['settings'] ) && ! empty( $field['settings'] ) ? $field['settings'] : array(),
+            'field_custom_fields' => isset( $field['custom_fields'] ) && ! empty( $field['custom_fields'] ) ? $field['custom_fields'] : array(),
             'post_id'           => $post->ID,
             'meta'              => true
           );

--- a/includes/ot-settings-api.php
+++ b/includes/ot-settings-api.php
@@ -517,6 +517,7 @@ if ( ! class_exists( 'OT_Settings' ) ) {
         'field_class'       => isset( $class ) ? $class : '',
         'field_choices'     => isset( $choices ) && ! empty( $choices ) ? $choices : array(),
         'field_settings'    => isset( $settings ) && ! empty( $settings ) ? $settings : array(),
+        'field_custom_fields' => isset( $custom_fields ) && ! empty( $custom_fields ) ? $custom_fields : array(),
         'post_id'           => ot_get_media_post_ID(),
         'get_option'        => $get_option,
       );


### PR DESCRIPTION
Added an optional custom_fields array to meta boxes and settings to provide additional arguments for custom OT types.
```
'custom_fields' => array(
  'info' => 'Some text',
  'hide'  => false
)
```
Using the `ot_display_by_type` filter would apply argument changes for all matching custom OT types, whereas the custom_fields array allows setting options for individual meta box & theme settings fields.

The custom fields are accessible in the custom OT type function via the `$field_custom_fields` array, e.g.: `$field_custom_fields['hide']`.