### PR TITLE
Hotfix: Google Fonts cause an error on w3 validator

### DIFF
--- a/includes/ot-functions.php
+++ b/includes/ot-functions.php
@@ -360,7 +360,7 @@ if ( ! function_exists( 'ot_load_google_fonts_css' ) ) {
         }
       }
 
-      wp_enqueue_style( 'ot-google-fonts', esc_url( '//fonts.googleapis.com/css?family=' . implode( '|', $families ) ) . $append, false, null );
+      wp_enqueue_style( 'ot-google-fonts', esc_url( '//fonts.googleapis.com/css?family=' . implode( '%7C', $families ) ) . $append, false, null );
     }
 
   }


### PR DESCRIPTION
Dear Derek,
Google fonts causes an error on W3 validator as you can see below.
`Bad value //fonts.googleapis.com/css?family=Lato:100,100italic,300,300italic,regular,italic,700,700italic,900,900italic|Roboto:regular&subset=latin,latin-ext for attribute href on element link: Illegal character in query: not a URL code point.`