### PR TITLE
Add support for aside, chat and status post formats meta boxes

### DIFF
--- a/assets/js/ot-postformats.js
+++ b/assets/js/ot-postformats.js
@@ -9,12 +9,15 @@
    * ====================== */
   var formats = "input.post-format"
     , metaboxes = [
-          '#ot-post-format-gallery'
+          '#ot-post-format-aside'
+        , '#ot-post-format-gallery'
         , '#ot-post-format-link'
         , '#ot-post-format-image'
         , '#ot-post-format-quote'
+        , '#ot-post-format-status'
         , '#ot-post-format-video'
         , '#ot-post-format-audio'
+        , '#ot-post-format-chat'
       ]
     , ids = metaboxes.join(',')
     , insertAfter = '#titlediv'

--- a/assets/js/ot-postformats.js
+++ b/assets/js/ot-postformats.js
@@ -10,14 +10,14 @@
   var formats = "input.post-format"
     , metaboxes = [
           '#ot-post-format-aside'
+        , '#ot-post-format-audio'
+        , '#ot-post-format-chat'
         , '#ot-post-format-gallery'
-        , '#ot-post-format-link'
         , '#ot-post-format-image'
+        , '#ot-post-format-link'
         , '#ot-post-format-quote'
         , '#ot-post-format-status'
         , '#ot-post-format-video'
-        , '#ot-post-format-audio'
-        , '#ot-post-format-chat'
       ]
     , ids = metaboxes.join(',')
     , insertAfter = '#titlediv'

--- a/includes/ot-post-formats-api.php
+++ b/includes/ot-post-formats-api.php
@@ -61,13 +61,13 @@ if ( ! class_exists( 'OT_Post_Formats' ) ) {
       if ( ! is_admin() )
         return false;
           
-      $meta_boxes = array(
+      $meta_boxes = apply_filters( 'ot_recognized_meta_boxes', array(
         ot_meta_box_post_format_gallery(),
         ot_meta_box_post_format_link(),
         ot_meta_box_post_format_quote(),
         ot_meta_box_post_format_video(),
         ot_meta_box_post_format_audio()
-      );
+      ));
       
       /**
        * Register our meta boxes using the 

--- a/includes/ot-post-formats-api.php
+++ b/includes/ot-post-formats-api.php
@@ -61,7 +61,7 @@ if ( ! class_exists( 'OT_Post_Formats' ) ) {
       if ( ! is_admin() )
         return false;
           
-      $meta_boxes = apply_filters( 'ot_recognized_meta_boxes', array(
+      $meta_boxes = apply_filters( 'ot_recognized_post_format_meta_boxes', array(
         ot_meta_box_post_format_gallery(),
         ot_meta_box_post_format_link(),
         ot_meta_box_post_format_quote(),


### PR DESCRIPTION
Check the below example for how to use it
```php
function ot_meta_box_post_format_status( $pages = 'post' ) {
  if ( ! current_theme_supports( 'post-formats' ) || ! in_array( 'status', current( get_theme_support( 'post-formats' ) ) ) )
    return false;
    
  if ( is_string( $pages ) )
    $pages = explode( ',', $pages );
  
  return array(
    'id'        => 'ot-post-format-status',
    'title'     => __( 'Status', 'option-tree' ),
    'desc'      => '',
    'pages'     => $pages,
    'context'   => 'side',
    'priority'  => 'low',
    'fields'    => array(
      array(
        'id'          => '_format_status',
        'label'       => '',
        'desc'        => '',
        'std'         => '',
        'type'        => 'textarea',
        'class'       => ''
      )
  	)
  );
}

add_filter( 'ot_recognized_post_format_meta_boxes', 'meta_box_post_format_status' );

function meta_box_post_format_status( $meta_boxes ) {
    $meta_boxes[] = ot_meta_box_post_format_status();
    return $meta_boxes;
}
```