### PR TITLE
Add hooks above and below the section's options

### DIFF
--- a/includes/ot-settings-api.php
+++ b/includes/ot-settings-api.php
@@ -881,7 +881,11 @@ if ( ! class_exists( 'OT_Settings' ) ) {
           
           echo '<div class="inside">';
           
+            do_action( 'ot_section_top', $page, $section );
+            
             $this->do_settings_fields( $page, $section['id'] );
+            
+            do_action( 'ot_section_bottom', $page, $section );
           
           echo '</div>';
           


### PR DESCRIPTION
This is useful if anyone want to display a message above or below the section's options. I have used it to display section title above its options.