### PR TITLE
Adding project type to composer file: wordpress-plugin

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,6 +1,7 @@
 {
   "name": "valendesigns/option-tree",
   "description": "Theme Options UI Builder for WordPress.",
+  "type": "wordpress-plugin",
   "homepage": "https://github.com/valendesigns/option-tree",
   "license": "GPLv3",
   "authors": [


### PR DESCRIPTION
The `composer/installers` project recognizes lots of different project types.  One of them is wordpress-plugin.

By specifying this, projects that install this plugin via `composer/installers` can have the plugin installed into a wp-plugins folder instead of the vendor folder.

Thanks for considering adding this to your project.
