### PR TITLE
Hotfix/radio checkbox styling

### DIFF
--- a/assets/css/ot-admin.css
+++ b/assets/css/ot-admin.css
@@ -2320,12 +2320,10 @@ select.option-tree-ui-select option {
   ---------------------------------------------------*/
 .format-setting.type-checkbox input,
 .format-setting.type-radio input {
-  float: left;
-  margin: 2px 5px 0 1px;
+  margin: 2px 5px 0 2px;
 }
 .format-setting.type-checkbox label,
 .format-setting.type-radio label {
-  float: left;
   max-width: 90%;
   padding: 0px;
 }


### PR DESCRIPTION
Fixed  styling issue inside Gutenberg metaboxes.

Gutenberg - Meta box Before : https://cl.ly/90a158028c7a
Gutenberg - Meta box After : https://cl.ly/b95b877ce0c0

Testing Theme Options Panel after hotfix.
https://cl.ly/b8f906460026 (Checkbox)
https://cl.ly/6afe5a824828 (radio)
https://cl.ly/18e3e7354cff (radio image)