### PR TITLE
FIX syntax error on plugin activation : You have an error in your SQL…

### DIFF
--- a/includes/ot-functions-admin.php
+++ b/includes/ot-functions-admin.php
@@ -1025,8 +1025,8 @@ if ( ! function_exists( 'ot_default_settings' ) ) {
 			$section_count  = 0;
 			$settings_count = 0;
 			$settings       = array();
-			$table_name     = $wpdb->prefix . 'option_tree';
-			$old_settings   = $wpdb->get_results( $wpdb->prepare( 'SELECT * FROM %s ORDER BY item_sort ASC', $table_name ) ); // phpcs:ignore
+            $table_name = "{$wpdb->prefix}option_tree";
+            $old_settings   = $wpdb->get_results( "SELECT * FROM $table_name ORDER BY item_sort ASC"); // phpcs:ignore
 			$find_table     = $wpdb->get_var( $wpdb->prepare( 'SHOW TABLES LIKE %s', $table_name ) ); // phpcs:ignore
 
 			if ( $old_settings && $find_table === $table_name ) {


### PR DESCRIPTION
Fixed syntax error on plugin activation : You have an error in your SQL syntax; check the manual that corresponds to your MySQL server version for the right syntax to use near ''wp_option_tree' ORDER BY item_sort ASC' at line 1

This was from ot-functions-admin.php - $wpdb->prepare was wrapping the table name in single quotes and MySQL didn’t like that. I took out the parepare because $wpdb->prefix it not meant to operate on user supplied data. I don’t think $wpdb->prefix should be considered user supplied but I suppose you could wrap some escaping code around $wpdb->prefix if you wanted to.

Example from Codex that does this: https://codex.wordpress.org/Class_Reference/wpdb

Some other articles:
https://wordpress.stackexchange.com/questions/191729/quotes-in-table-name
https://wordpress.stackexchange.com/questions/93830/really-simple-query-giving-error-in-sql-syntax/93861#93861