### PR TITLE
Datepicker not rendering in new List Item

### DIFF
--- a/includes/ot-functions-option-types.php
+++ b/includes/ot-functions-option-types.php
@@ -950,9 +950,6 @@ if ( ! function_exists( 'ot_type_date_time_picker' ) ) {
 		// Format setting outer wrapper.
 		echo '<div class="format-setting type-date-time-picker ' . ( $has_desc ? 'has-desc' : 'no-desc' ) . '">';
 
-		// Date time picker JS.
-		echo '<script>jQuery(document).ready(function($) { OT_UI.bind_date_time_picker("' . esc_attr( $field_id ) . '", "' . esc_attr( $date_format ) . '"); });</script>';
-
 		// Description.
 		echo $has_desc ? '<div class="description">' . wp_kses_post( htmlspecialchars_decode( $field_desc ) ) . '</div>' : '';
 
@@ -962,6 +959,9 @@ if ( ! function_exists( 'ot_type_date_time_picker' ) ) {
 		// Build date time picker.
 		echo '<input type="text" name="' . esc_attr( $field_name ) . '" id="' . esc_attr( $field_id ) . '" value="' . esc_attr( $field_value ) . '" class="widefat option-tree-ui-input ' . esc_attr( $field_class ) . '"' . ( true === $is_readonly ? ' readonly' : '' ) . ' />';
 
+		// Date picker JS.
+		echo '<script>OT_UI.bind_date_picker("' . esc_attr( $field_id ) . '", "' . esc_attr( $date_format ) . '");</script>';
+		
 		echo '</div>';
 
 		echo '</div>';

--- a/includes/ot-functions-option-types.php
+++ b/includes/ot-functions-option-types.php
@@ -961,7 +961,7 @@ if ( ! function_exists( 'ot_type_date_time_picker' ) ) {
 
 		// Date picker JS.
 		echo '<script>OT_UI.bind_date_picker("' . esc_attr( $field_id ) . '", "' . esc_attr( $date_format ) . '");</script>';
-		
+
 		echo '</div>';
 
 		echo '</div>';


### PR DESCRIPTION
There's a bug where the date picker is not being triggered when you create a new List Item because the date picker function is not triggered again.

The current code initialises each datepicker field on document ready. When you add a new List Item, the JS code is injected in the DOM but it does not evaluate because it is wrapped in the document ready wrapper.

In this PR, I've unwrapped the JS code from the document ready wrapper and added it after the input field. Document ready is no more needed since the new input field is already loaded in the DOM when the JS code is being evaluated. When you add a new List Item, the JS code injected will also be evaluated.