### PR TITLE
Fix for regex on ot_decode not accepting letter "O"

### DIFF
--- a/includes/ot-functions-admin.php
+++ b/includes/ot-functions-admin.php
@@ -5057,7 +5057,7 @@ if ( ! function_exists( 'ot_decode' ) ) {
 		preg_match( '/a:\d+:{.*?}/', $decoded, $array_matches, PREG_OFFSET_CAPTURE, 0 );
 
 		// Search for an object.
-		preg_match( '/O|C:\+?\d+:"[a-z0-9_]+":\+?\d+:/i', $decoded, $obj_matches, PREG_OFFSET_CAPTURE, 0 );
+		preg_match( '/O:\+?\d+:"[a-z0-9_]+":\+?\d+:|C:\+?\d+:"[a-z0-9_]+":\+?\d+:/i', $decoded, $obj_matches, PREG_OFFSET_CAPTURE, 0 );
 
 		// Prevent object injection or non arrays.
 		if ( $obj_matches || ! $array_matches ) {


### PR DESCRIPTION
Having the letter "O" anywhere in the values being imported throws an error because the regex is incomplete for detecting serialized objects